### PR TITLE
Improve end-to-end timeline representation

### DIFF
--- a/src/Arcus.API.Bacon/Arcus.API.Bacon.csproj
+++ b/src/Arcus.API.Bacon/Arcus.API.Bacon.csproj
@@ -17,8 +17,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Arcus.Security.Core" Version="1.6.0" />
-    <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="1.6.0" />
+    <PackageReference Include="Arcus.Security.Core" Version="1.7.0" />
+    <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="1.7.0" />
     <PackageReference Include="Bogus" Version="33.0.2" />
     <PackageReference Include="Guard.NET" Version="1.2.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.14" />

--- a/src/Arcus.API.Bacon/Repositories/BaconRepository.cs
+++ b/src/Arcus.API.Bacon/Repositories/BaconRepository.cs
@@ -23,7 +23,7 @@ namespace Arcus.API.Bacon.Repositories
 
         public async Task<List<string>> GetFlavorsAsync()
         {
-            using (var dependencyMeasurement = DependencyMeasurement.Start("Get Bacon"))
+            using (var durationMeasurement = DurationMeasurement.Start())
             {
                 try
                 {
@@ -45,7 +45,7 @@ namespace Arcus.API.Bacon.Repositories
                 finally
                 {
                     // Normally you would do it in the repo but ok
-                    _logger.LogSqlDependency("example-server", "bacon-db", "flavors", isSuccessful:true, dependencyMeasurement);
+                    _logger.LogSqlDependency("example-server", "bacon-db", "flavors", isSuccessful: true, operationName: "Get Bacon", startTime: durationMeasurement.StartTime , duration: durationMeasurement.Elapsed);
                 }
             }
 

--- a/src/Arcus.API.Market/Arcus.API.Market.csproj
+++ b/src/Arcus.API.Market/Arcus.API.Market.csproj
@@ -17,8 +17,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Arcus.Security.Core" Version="1.6.0" />
-    <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="1.6.0" />
+    <PackageReference Include="Arcus.Security.Core" Version="1.7.0" />
+    <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="1.7.0" />
     <PackageReference Include="Bogus" Version="33.0.2" />
     <PackageReference Include="Guard.NET" Version="1.2.0" />
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="5.1.3" />

--- a/src/Arcus.API.Market/Repositories/OrderRepository.cs
+++ b/src/Arcus.API.Market/Repositories/OrderRepository.cs
@@ -35,7 +35,7 @@ namespace Arcus.API.Market.Repositories
                 Amount = amount
             };
 
-            using (var serviceBusDependencyMeasurement = DependencyMeasurement.Start("Order Bacon"))
+            using (var serviceBusDependencyMeasurement = DurationMeasurement.Start())
             {
                 bool isSuccessful = false;
                 var correlationInfo = _correlationInfoAccessor.GetCorrelationInfo();
@@ -54,6 +54,7 @@ namespace Arcus.API.Market.Repositories
                 {
                     // TODO: Support linking as well
                     var serviceBusEndpoint = _queueClient.ServiceBusConnection.Endpoint.ToString();
+                    _logger.LogInformation($"Done sending at {DateTimeOffset.UtcNow}");
                     _logger.LogExtendedServiceBusQueueDependency(serviceBusEndpoint, _queueClient.QueueName, isSuccessful, serviceBusDependencyMeasurement, dependencyId: upstreamOperationParentId);
                 }                
             }

--- a/src/Arcus.POC.Messaging.Abstractions/Arcus.POC.Messaging.Abstractions.csproj
+++ b/src/Arcus.POC.Messaging.Abstractions/Arcus.POC.Messaging.Abstractions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <PackageId>Arcus.Messaging.Abstractions</PackageId>
     <Authors>Arcus</Authors>
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Arcus.Observability.Correlation" Version="2.2.2" />
+    <PackageReference Include="Arcus.Observability.Correlation" Version="2.4.0" />
     <PackageReference Include="Guard.NET" Version="1.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.8" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.8" />

--- a/src/Arcus.POC.Messaging.Abstractions/MessageCorrelationInfo.cs
+++ b/src/Arcus.POC.Messaging.Abstractions/MessageCorrelationInfo.cs
@@ -4,7 +4,7 @@ using Arcus.Observability.Correlation;
 namespace Arcus.POC.Messaging.Abstractions
 {
     /// <summary>
-    ///     Information concerning correlation of telemetry & processes with main focus on messaging scenarios
+    ///     Information concerning correlation of telemetry and processes with main focus on messaging scenarios
     /// </summary>
     public class MessageCorrelationInfo : CorrelationInfo
     {

--- a/src/Arcus.POC.Messaging.Pumps.Abstractions/Arcus.POC.Messaging.Pumps.Abstractions.csproj
+++ b/src/Arcus.POC.Messaging.Pumps.Abstractions/Arcus.POC.Messaging.Pumps.Abstractions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <PackageId>Arcus.Messaging.Pumps.Abstractions</PackageId>
     <Authors>Arcus</Authors>
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Enrichers" Version="2.2.2" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Enrichers" Version="2.4.0" />
     <PackageReference Include="Guard.NET" Version="1.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.8" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.8" />

--- a/src/Arcus.POC.Messaging.Pumps.Abstractions/MessageHandling/MessageHandler.cs
+++ b/src/Arcus.POC.Messaging.Pumps.Abstractions/MessageHandling/MessageHandler.cs
@@ -121,7 +121,6 @@ namespace Arcus.POC.Messaging.Pumps.Abstractions.MessageHandling
         ///     [true] if the registered <typeparamref name="TMessageContext"/> predicate holds; [false] otherwise.
         /// </returns>
         /// <typeparam name="TMessageContext">The type of the message context.</typeparam>
-        /// <param name="messageContext">The context in which the incoming message is processed.</param>
         [Obsolete("Use the " + nameof(CanProcessMessageBasedOnContext) + " specific message context overload instead")]
         public bool CanProcessMessage<TMessageContext>(TMessageContext messageContext)
             where TMessageContext : MessageContext

--- a/src/Arcus.POC.Messaging.Pumps.ServiceBus/Arcus.POC.Messaging.Pumps.ServiceBus.csproj
+++ b/src/Arcus.POC.Messaging.Pumps.ServiceBus/Arcus.POC.Messaging.Pumps.ServiceBus.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <PackageId>Arcus.Messaging.Pumps.ServiceBus</PackageId>
     <Authors>Arcus</Authors>
@@ -20,9 +20,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="1.3.0" />
+    <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="1.7.0" />
     <PackageReference Include="Guard.NET" Version="1.2.0" />
-    <PackageReference Include="Microsoft.Azure.KeyVault" Version="3.0.4" />
+    <PackageReference Include="Microsoft.Azure.KeyVault" Version="3.0.5" />
     <PackageReference Include="Microsoft.Azure.Management.ServiceBus" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.8" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.8" />

--- a/src/Arcus.POC.Messaging.Pumps.ServiceBus/AzureServiceBusMessagePump.cs
+++ b/src/Arcus.POC.Messaging.Pumps.ServiceBus/AzureServiceBusMessagePump.cs
@@ -563,7 +563,7 @@ namespace Arcus.POC.Messaging.Pumps.ServiceBus
             {
                 // TODO: Simplify this approach
                 bool isSuccessful = false;
-                using(var dependencyMeasurement = DependencyMeasurement.Start("Process"))
+                using(var dependencyMeasurement = DurationMeasurement.Start())
                 {
                     try
                     {
@@ -593,7 +593,10 @@ namespace Arcus.POC.Messaging.Pumps.ServiceBus
                     {
                         var entityName = _messageReceiver.Path;
                         var serviceBusNamespace = _messageReceiver.ServiceBusConnection.Endpoint.ToString();
-                        Logger.LogServiceBusQueueRequest(serviceBusNamespace, entityName, isSuccessful, dependencyMeasurement.Elapsed, dependencyMeasurement.StartTime);
+                        Logger.LogServiceBusQueueRequest(serviceBusNamespace, entityName, isSuccessful,
+                                                         dependencyMeasurement.StartTime,
+                                                         dependencyMeasurement.Elapsed,
+                                                         operationName: "Process");
                     }
                 }
             }

--- a/src/Arcus.POC.Messaging.ServiceBus.Core/Arcus.POC.Messaging.ServiceBus.Core.csproj
+++ b/src/Arcus.POC.Messaging.ServiceBus.Core/Arcus.POC.Messaging.ServiceBus.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>latest</LangVersion>
     <PackageId>Arcus.Messaging.ServiceBus.Core</PackageId>
     <Authors>Arcus</Authors>

--- a/src/Arcus.POC.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Arcus.POC.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.csproj
+++ b/src/Arcus.POC.Observability.Telemetry.Serilog.Sinks.ApplicationInsights/Arcus.POC.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <PackageId>Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights</PackageId>
     <Authors>Arcus</Authors>
     <Company>Arcus</Company>
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="2.2.2" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="2.4.0" />
     <PackageReference Include="Guard.NET" Version="1.2.0" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.13.1" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />

--- a/src/Arcus.POC.WebApi.Logging.Core/Arcus.POC.WebApi.Logging.Core.csproj
+++ b/src/Arcus.POC.WebApi.Logging.Core/Arcus.POC.WebApi.Logging.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <Authors>Arcus</Authors>
     <Company>Arcus</Company>
     <RepositoryType>Git</RepositoryType>
@@ -27,8 +27,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="2.2.2" />
-    <PackageReference Include="Arcus.Observability.Correlation" Version="2.2.2" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="2.4.0" />
+    <PackageReference Include="Arcus.Observability.Correlation" Version="2.4.0" />
     <PackageReference Include="Guard.Net" Version="1.2.0" />
   </ItemGroup>
 

--- a/src/Arcus.POC.WebApi.Logging/Arcus.POC.WebApi.Logging.csproj
+++ b/src/Arcus.POC.WebApi.Logging/Arcus.POC.WebApi.Logging.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>    
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>    
     <Authors>Arcus</Authors>
     <Company>Arcus</Company>
     <RepositoryType>Git</RepositoryType>
@@ -31,10 +31,10 @@
 
   <ItemGroup>
     <PackageReference Include="Guard.Net" Version="1.2.0" />
-    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="2.2.2" />
-    <PackageReference Include="Arcus.Observability.Telemetry.AspNetCore" Version="2.2.2" />
-    <PackageReference Include="Arcus.Observability.Correlation" Version="2.2.2" />
-    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Enrichers" Version="2.2.2" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="2.4.0" />
+    <PackageReference Include="Arcus.Observability.Telemetry.AspNetCore" Version="2.4.0" />
+    <PackageReference Include="Arcus.Observability.Correlation" Version="2.4.0" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Enrichers" Version="2.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Arcus.Shared/Arcus.Shared.csproj
+++ b/src/Arcus.Shared/Arcus.Shared.csproj
@@ -1,11 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Enrichers" Version="2.2.2" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Enrichers" Version="2.4.0" />
     <PackageReference Include="Bogus" Version="33.0.2" />
     <PackageReference Include="Guard.NET" Version="1.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/src/Arcus.Shared/Extensions/HttpClientExtensions.cs
+++ b/src/Arcus.Shared/Extensions/HttpClientExtensions.cs
@@ -13,7 +13,7 @@ namespace System.Net.Http
         // TODO: Contribute Upstream - HTTP service-to-service automagical tracking - Option #2 - Use extension, but end-users need to specify all dependencies
         public static async Task<HttpResponseMessage> SendAndTrackDependencyAsync(this HttpClient httpClient, string operationName, HttpRequestMessage request, ICorrelationInfoAccessor correlationInfoAccessor, ILogger logger)
         {
-            using (var httpDependencyMeasurement = DependencyMeasurement.Start(operationName))
+            using (var httpDependencyMeasurement = DurationMeasurement.Start())
             {
                 var newDependencyId = Guid.NewGuid().ToString();
                 var correlationInfo = correlationInfoAccessor.GetCorrelationInfo();

--- a/src/Arcus.Shared/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Shared/Extensions/IServiceCollectionExtensions.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            using (var httpDependencyMeasurement = DependencyMeasurement.Start())
+            using (var httpDependencyMeasurement = DurationMeasurement.Start())
             {
                 var newDependencyId = Guid.NewGuid().ToString();
                 // TODO: Fix DI scoping issue here again, doesn't work for messaging

--- a/src/Arcus.Shared/Services/BaconService.cs
+++ b/src/Arcus.Shared/Services/BaconService.cs
@@ -36,10 +36,17 @@ namespace Arcus.Shared.Services
         {
             var url = _configuration["Bacon_API_Url"];
 
-            var request = new HttpRequestMessage(HttpMethod.Get, $"http://{url}/api/v1/bacon");
+            var requestUri = $"http://{url}/api/v1/bacon";
+
+            _logger.LogInformation($"Requesting BACON at {requestUri}");
+
+            var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
 
             var response = await SendHttpRequestAsync("Get Bacon", request);
-            if (response.IsSuccessStatusCode == false) throw new Exception("Unable to get bacon");
+            if (response.IsSuccessStatusCode == false)
+            {
+                throw new Exception("Unable to get bacon");
+            }
 
             var rawResponse = await response.Content.ReadAsStringAsync();
             return JsonConvert.DeserializeObject<List<string>>(rawResponse);

--- a/src/Arcus.Workers.Orders/Arcus.Workers.Orders.csproj
+++ b/src/Arcus.Workers.Orders/Arcus.Workers.Orders.csproj
@@ -7,10 +7,10 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Arcus.Messaging.Health" Version="0.6.0" />
-    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="2.2.2" />
-    <PackageReference Include="Arcus.Security.Core" Version="1.6.0" />
-    <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="1.6.0" />
+    <PackageReference Include="Arcus.Messaging.Health" Version="1.2.0" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="2.4.0" />
+    <PackageReference Include="Arcus.Security.Core" Version="1.7.0" />
+    <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="1.7.0" />
     <PackageReference Include="Guard.NET" Version="1.2.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.14" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />


### PR DESCRIPTION
The start-date of an HTTP request is not correctly logged.  This PR fixes this.  Next to that, I've also upgraded the Arcus packages that are referenced.