### PR TITLE
chore: upgrade to webapi v1.6

### DIFF
--- a/src/Arcus.API.Bacon/Arcus.API.Bacon.csproj
+++ b/src/Arcus.API.Bacon/Arcus.API.Bacon.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <DocumentationFile>Arcus.API.Bacon.Open-Api.xml</DocumentationFile>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerComposeProjectPath>..\docker-compose.dcproj</DockerComposeProjectPath>
@@ -19,13 +19,13 @@
   <ItemGroup>
     <PackageReference Include="Arcus.Security.Core" Version="1.7.0" />
     <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="1.7.0" />
+    <PackageReference Include="Arcus.WebApi.Logging" Version="1.6.1-preview-1" />
     <PackageReference Include="Bogus" Version="33.0.2" />
     <PackageReference Include="Guard.NET" Version="1.2.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.14" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Arcus.POC.WebApi.Logging\Arcus.POC.WebApi.Logging.csproj" />
     <ProjectReference Include="..\Arcus.Shared\Arcus.Shared.csproj" />
   </ItemGroup>
 

--- a/src/Arcus.API.Bacon/Arcus.API.Bacon.csproj
+++ b/src/Arcus.API.Bacon/Arcus.API.Bacon.csproj
@@ -19,7 +19,7 @@
   <ItemGroup>
     <PackageReference Include="Arcus.Security.Core" Version="1.7.0" />
     <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="1.7.0" />
-    <PackageReference Include="Arcus.WebApi.Logging" Version="1.6.1-preview-1" />
+    <PackageReference Include="Arcus.WebApi.Logging" Version="1.6.1" />
     <PackageReference Include="Bogus" Version="33.0.2" />
     <PackageReference Include="Guard.NET" Version="1.2.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.14" />

--- a/src/Arcus.API.Bacon/Repositories/BaconRepository.cs
+++ b/src/Arcus.API.Bacon/Repositories/BaconRepository.cs
@@ -45,7 +45,15 @@ namespace Arcus.API.Bacon.Repositories
                 finally
                 {
                     // Normally you would do it in the repo but ok
-                    _logger.LogSqlDependency("example-server", "bacon-db", "flavors", isSuccessful: true, operationName: "Get Bacon", startTime: durationMeasurement.StartTime , duration: durationMeasurement.Elapsed);
+                    _logger.LogSqlDependency(
+                        "example-server", 
+                        "bacon-db", 
+                        sqlCommand: "GET FlavorName FROM Flavors", 
+                        isSuccessful: true, 
+                        operationName: "Get Bacon Flavors", 
+                        startTime: durationMeasurement.StartTime , 
+                        duration: durationMeasurement.Elapsed,
+                        dependencyId: null);
                 }
             }
 

--- a/src/Arcus.API.Market/Arcus.API.Market.Open-Api.xml
+++ b/src/Arcus.API.Market/Arcus.API.Market.Open-Api.xml
@@ -41,5 +41,15 @@
             <response code="201">Order is created</response>
             <response code="503">Uh-oh! Things went wrong</response>
         </member>
+        <member name="M:Arcus.API.Market.Extensions.ObjectExtensions.AsServiceBusMessage(System.Object,System.String,System.String,System.String,System.Text.Encoding)">
+            <summary>
+                Creates an Azure Service Bus Message for a message body
+            </summary>
+            <param name="messageBody">Body of the Service Bus message to process</param>
+            <param name="operationId">Unique identifier that spans one operation end-to-end</param>
+            <param name="transactionId">Unique identifier that spans one or more operations and are considered a transaction/session</param>
+            <param name="encoding">Encoding to use during serialization. Defaults to UTF8</param>
+            <returns>Azure Service Bus Message</returns>
+        </member>
     </members>
 </doc>

--- a/src/Arcus.API.Market/Arcus.API.Market.csproj
+++ b/src/Arcus.API.Market/Arcus.API.Market.csproj
@@ -29,7 +29,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!--<ProjectReference Include="..\Arcus.POC.WebApi.Logging\Arcus.POC.WebApi.Logging.csproj" />-->
     <ProjectReference Include="..\Arcus.Shared\Arcus.Shared.csproj" />
   </ItemGroup>
 

--- a/src/Arcus.API.Market/Arcus.API.Market.csproj
+++ b/src/Arcus.API.Market/Arcus.API.Market.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Arcus.Messaging.ServiceBus.Core" Version="1.3.0-preview-1" />
-    <PackageReference Include="Arcus.WebApi.Logging" Version="1.6.1-preview-1" />
+    <PackageReference Include="Arcus.WebApi.Logging" Version="1.6.1" />
     <PackageReference Include="Arcus.Security.Core" Version="1.7.0" />
     <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="1.7.0" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.8.1" />

--- a/src/Arcus.API.Market/Arcus.API.Market.csproj
+++ b/src/Arcus.API.Market/Arcus.API.Market.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Arcus.Messaging.ServiceBus.Core" Version="1.3.0-preview-1" />
+    <PackageReference Include="Arcus.WebApi.Logging" Version="1.6.1-preview-1" />
     <PackageReference Include="Arcus.Security.Core" Version="1.7.0" />
     <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="1.7.0" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.8.1" />
@@ -28,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Arcus.POC.WebApi.Logging\Arcus.POC.WebApi.Logging.csproj" />
+    <!--<ProjectReference Include="..\Arcus.POC.WebApi.Logging\Arcus.POC.WebApi.Logging.csproj" />-->
     <ProjectReference Include="..\Arcus.Shared\Arcus.Shared.csproj" />
   </ItemGroup>
 

--- a/src/Arcus.API.Market/Repositories/OrderRepository.cs
+++ b/src/Arcus.API.Market/Repositories/OrderRepository.cs
@@ -64,18 +64,7 @@ namespace Arcus.API.Market.Repositories
                     var serviceBusEndpoint = _serviceBusOrderSender.FullyQualifiedNamespace;
                     string entityPath = _serviceBusOrderSender.EntityPath;
                     _logger.LogInformation($"Done sending at {DateTimeOffset.UtcNow}");
-                    //_logger.LogServiceBusQueueDependency(serviceBusEndpoint, entityPath, isSuccessful, serviceBusDependencyMeasurement, dependencyId: newDependencyId);
-                    _logger.LogWarning(MessageFormats.DependencyFormat, new DependencyLogEntry(
-                        "Azure Service Bus",
-                        entityPath,
-                        null,
-                        entityPath,
-                        newDependencyId,
-                        serviceBusDependencyMeasurement.Elapsed,
-                        serviceBusDependencyMeasurement.StartTime,
-                        null,
-                        isSuccessful,
-                        new Dictionary<string, object>()));
+                    _logger.LogServiceBusQueueDependency(serviceBusEndpoint, entityPath, isSuccessful, serviceBusDependencyMeasurement, dependencyId: newDependencyId);
                 }
             }
         }

--- a/src/Arcus.API.Market/Repositories/OrderRepository.cs
+++ b/src/Arcus.API.Market/Repositories/OrderRepository.cs
@@ -1,9 +1,11 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Arcus.API.Market.Extensions;
 using Arcus.API.Market.Repositories.Interfaces;
 using Arcus.Observability.Correlation;
 using Arcus.Observability.Telemetry.Core;
+using Arcus.Observability.Telemetry.Core.Logging;
 using Arcus.Shared.Messages;
 using GuardNet;
 using Microsoft.Extensions.Logging;
@@ -44,7 +46,7 @@ namespace Arcus.API.Market.Repositories
                 var correlationInfo = _correlationInfoAccessor.GetCorrelationInfo();
                 var newOperationId = $"operation-{Guid.NewGuid()}";
                 var newDependencyId = Guid.NewGuid().ToString();
-                
+
                 try
                 {
                     var serviceBusMessage = ServiceBusMessageBuilder.CreateForBody(orderRequest)
@@ -60,8 +62,20 @@ namespace Arcus.API.Market.Repositories
                 finally
                 {
                     var serviceBusEndpoint = _serviceBusOrderSender.FullyQualifiedNamespace;
+                    string entityPath = _serviceBusOrderSender.EntityPath;
                     _logger.LogInformation($"Done sending at {DateTimeOffset.UtcNow}");
-                    _logger.LogServiceBusQueueDependency(_serviceBusOrderSender.EntityPath, isSuccessful, serviceBusDependencyMeasurement, dependencyId: newDependencyId);
+                    //_logger.LogServiceBusQueueDependency(serviceBusEndpoint, entityPath, isSuccessful, serviceBusDependencyMeasurement, dependencyId: newDependencyId);
+                    _logger.LogWarning(MessageFormats.DependencyFormat, new DependencyLogEntry(
+                        "Azure Service Bus",
+                        entityPath,
+                        null,
+                        entityPath,
+                        newDependencyId,
+                        serviceBusDependencyMeasurement.Elapsed,
+                        serviceBusDependencyMeasurement.StartTime,
+                        null,
+                        isSuccessful,
+                        new Dictionary<string, object>()));
                 }
             }
         }

--- a/src/Arcus.Shared/Arcus.Shared.csproj
+++ b/src/Arcus.Shared/Arcus.Shared.csproj
@@ -6,9 +6,9 @@
 
   <ItemGroup>
     <PackageReference Include="Arcus.Messaging.Abstractions" Version="1.3.0-preview-1" />
-    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Enrichers" Version="2.5.0" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Enrichers" Version="2.6.0" />
     <PackageReference Include="Arcus.WebApi.Logging" Version="1.6.1-preview-1" />
-    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights" Version="2.5.0" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights" Version="2.6.0" />
     <PackageReference Include="Bogus" Version="33.0.2" />
     <PackageReference Include="Guard.NET" Version="1.2.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.9" />

--- a/src/Arcus.Shared/Arcus.Shared.csproj
+++ b/src/Arcus.Shared/Arcus.Shared.csproj
@@ -21,8 +21,4 @@
     <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="7.0.2" />
   </ItemGroup>
 
-  <ItemGroup>
-    <!--<ProjectReference Include="..\Arcus.POC.Observability.Telemetry.Serilog.Sinks.ApplicationInsights\Arcus.POC.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.csproj" />-->
-  </ItemGroup>
-
 </Project>

--- a/src/Arcus.Shared/Arcus.Shared.csproj
+++ b/src/Arcus.Shared/Arcus.Shared.csproj
@@ -6,7 +6,9 @@
 
   <ItemGroup>
     <PackageReference Include="Arcus.Messaging.Abstractions" Version="1.3.0-preview-1" />
-    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Enrichers" Version="2.5.0-preview-1" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Enrichers" Version="2.5.0" />
+    <PackageReference Include="Arcus.WebApi.Logging" Version="1.6.1-preview-1" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights" Version="2.5.0" />
     <PackageReference Include="Bogus" Version="33.0.2" />
     <PackageReference Include="Guard.NET" Version="1.2.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.9" />
@@ -20,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Arcus.POC.Observability.Telemetry.Serilog.Sinks.ApplicationInsights\Arcus.POC.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.csproj" />
+    <!--<ProjectReference Include="..\Arcus.POC.Observability.Telemetry.Serilog.Sinks.ApplicationInsights\Arcus.POC.Observability.Telemetry.Serilog.Sinks.ApplicationInsights.csproj" />-->
   </ItemGroup>
 
 </Project>

--- a/src/Arcus.Shared/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Shared/Extensions/IServiceCollectionExtensions.cs
@@ -15,14 +15,15 @@ namespace Microsoft.Extensions.DependencyInjection
     {
         public static void AddBaconApiIntegration(this IServiceCollection services)
         {
-            services.AddHttpClient();
+            services.AddHttpClient("Bacon API")
+                    .WithHttpCorrelationTracking();
 
             // TODO: Contribute Upstream - HTTP service-to-service automagical tracking - Option #1 - Use HTTP pipeline, if we can fix the DI scoping for all scenarios
             // Remove name requirement as this is an extension workaround
             // https://thomaslevesque.com/2016/12/08/fun-with-the-httpclient-pipeline/
             // services.AddTransient<DependencyTrackingHttpHandler>();
             //services.AddHttpClient("SomeName")
-                      //.AddHttpMessageHandler(serviceProvider => serviceProvider.GetRequiredService<DependencyTrackingHttpHandler>());
+            //.AddHttpMessageHandler(serviceProvider => serviceProvider.GetRequiredService<DependencyTrackingHttpHandler>());
 
             services.AddScoped<IBaconService, BaconService>();
         }

--- a/src/Arcus.Shared/SerilogFactory.cs
+++ b/src/Arcus.Shared/SerilogFactory.cs
@@ -25,9 +25,7 @@ namespace Arcus.Shared
 
             if (useHttpCorrelation)
             {
-                var httpContextAccessor = serviceProvider.GetRequiredService<IHttpContextAccessor>();
-
-                loggerConfiguration = loggerConfiguration.Enrich.WithCorrelationInfo(new CustomHttpCorrelationInfoAccessor(httpContextAccessor));
+                loggerConfiguration = loggerConfiguration.Enrich.WithHttpCorrelationInfo(serviceProvider);
             }
 
             loggerConfiguration = loggerConfiguration.WriteTo.Console()

--- a/src/Arcus.Shared/Services/BaconService.cs
+++ b/src/Arcus.Shared/Services/BaconService.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Arcus.Messaging.Abstractions;
 using Arcus.Observability.Correlation;
 using Arcus.Shared.Services.Interfaces;
+using Arcus.WebApi.Logging.Core.Correlation;
 using GuardNet;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
@@ -36,16 +37,13 @@ namespace Arcus.Shared.Services
         public async Task<List<string>> GetBaconAsync()
         {
             var url = _configuration["Bacon_API_Url"];
-
             var requestUri = $"http://{url}/api/v1/bacon";
-            //var requestUri = $"http://localhost:789/api/v1/bacon";
-
             _logger.LogInformation($"Requesting BACON at {requestUri}");
 
             var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
 
-            var httpClient = _httpClientFactory.CreateClient();
-            var response = await httpClient.SendAndTrackDependencyAsync("Get Bacon", request, _correlationInfoAccessor, _logger);
+            var httpClient = _httpClientFactory.CreateClient("Bacon API");
+            var response = await httpClient.SendAsync(request);
 
             _logger.LogInformation("Calling bacon API completed with status:" + response.StatusCode);
 
@@ -63,14 +61,13 @@ namespace Arcus.Shared.Services
             var url = _configuration["Bacon_API_Url"];
 
             var requestUri = $"http://{url}/api/v1/bacon";
-            //var requestUri = $"http://localhost:789/api/v1/bacon";
 
             _logger.LogInformation($"Requesting BACON at {requestUri}");
 
             var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
 
             var httpClient = _httpClientFactory.CreateClient();
-            var response = await httpClient.SendAndTrackDependencyAsync("Get Bacon", request, messageCorrelationInfo, _logger);
+            var response = await httpClient.SendAsync(request, messageCorrelationInfo, _logger);
 
             _logger.LogInformation("Calling bacon API completed with status:" + response.StatusCode);
 

--- a/src/Arcus.Workers.Orders/Arcus.Workers.Orders.csproj
+++ b/src/Arcus.Workers.Orders/Arcus.Workers.Orders.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Arcus.Messaging.Pumps.Abstractions" Version="1.3.0-preview-1" />
     <PackageReference Include="Arcus.Messaging.Pumps.ServiceBus" Version="1.3.0-preview-1" />
     <PackageReference Include="Arcus.Messaging.ServiceBus.Core" Version="1.3.0-preview-1" />
-    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="2.5.0-preview-1" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="2.5.0" />
     <PackageReference Include="Arcus.Security.Core" Version="1.7.0" />
     <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="1.7.0" />
     <PackageReference Include="Guard.NET" Version="1.2.0" />

--- a/src/Arcus.Workers.Orders/Arcus.Workers.Orders.csproj
+++ b/src/Arcus.Workers.Orders/Arcus.Workers.Orders.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Arcus.Messaging.Pumps.Abstractions" Version="1.3.0-preview-1" />
     <PackageReference Include="Arcus.Messaging.Pumps.ServiceBus" Version="1.3.0-preview-1" />
     <PackageReference Include="Arcus.Messaging.ServiceBus.Core" Version="1.3.0-preview-1" />
-    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="2.5.0" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="2.6.0" />
     <PackageReference Include="Arcus.Security.Core" Version="1.7.0" />
     <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="1.7.0" />
     <PackageReference Include="Guard.NET" Version="1.2.0" />


### PR DESCRIPTION
Upgrade to the newest version of Arcus WebAPI to make use of the HTTP client correlation tracking feautres.